### PR TITLE
[Feat] Score,PotionItem 및 이펙트들 추가

### DIFF
--- a/Assets/LHJ/Matarials/Potionmatarial.mat
+++ b/Assets/LHJ/Matarials/Potionmatarial.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Potionmatarial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 0.17727685, g: 1, b: 0, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/LHJ/Matarials/Potionmatarial.mat.meta
+++ b/Assets/LHJ/Matarials/Potionmatarial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: cd25c5347c670b94bbfb90a056b6ef8e
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LHJ/Matarials/ScoreItemmatarial.mat
+++ b/Assets/LHJ/Matarials/ScoreItemmatarial.mat
@@ -78,6 +78,6 @@ Material:
     - _UVSec: 0
     - _ZWrite: 1
     m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _Color: {r: 1, g: 0.94525766, b: 0.49371064, a: 1}
     - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
   m_BuildTextureStacks: []

--- a/Assets/LHJ/Matarials/ScoreItemmatarial.mat
+++ b/Assets/LHJ/Matarials/ScoreItemmatarial.mat
@@ -1,0 +1,83 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 8
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ScoreItemmatarial
+  m_Shader: {fileID: 46, guid: 0000000000000000f000000000000000, type: 0}
+  m_Parent: {fileID: 0}
+  m_ModifiedSerializedProperties: 0
+  m_ValidKeywords: []
+  m_InvalidKeywords: []
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_LockedProperties: 
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _BumpMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailAlbedoMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailMask:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _DetailNormalMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _EmissionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _MetallicGlossMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _OcclusionMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - _ParallaxMap:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Ints: []
+    m_Floats:
+    - _BumpScale: 1
+    - _Cutoff: 0.5
+    - _DetailNormalMapScale: 1
+    - _DstBlend: 0
+    - _GlossMapScale: 1
+    - _Glossiness: 0.5
+    - _GlossyReflections: 1
+    - _Metallic: 0
+    - _Mode: 0
+    - _OcclusionStrength: 1
+    - _Parallax: 0.02
+    - _SmoothnessTextureChannel: 0
+    - _SpecularHighlights: 1
+    - _SrcBlend: 1
+    - _UVSec: 0
+    - _ZWrite: 1
+    m_Colors:
+    - _Color: {r: 1, g: 1, b: 1, a: 1}
+    - _EmissionColor: {r: 0, g: 0, b: 0, a: 1}
+  m_BuildTextureStacks: []

--- a/Assets/LHJ/Matarials/ScoreItemmatarial.mat.meta
+++ b/Assets/LHJ/Matarials/ScoreItemmatarial.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ee91e59881146564b8f1b22f0164cc5f
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 2100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LHJ/Prefabs/AttackItem.prefab
+++ b/Assets/LHJ/Prefabs/AttackItem.prefab
@@ -120,3 +120,4 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   attackIncrease: 3
   buffTime: 5
+  powerupEffect: {fileID: 572420816548206666, guid: 1b56a3ab4afd11d4db07245a18cd4cf2, type: 3}

--- a/Assets/LHJ/Prefabs/PotionItem.prefab
+++ b/Assets/LHJ/Prefabs/PotionItem.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &5753383277287633024
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1582631074212584446}
+  - component: {fileID: 2541276210167708455}
+  - component: {fileID: 1689049321893325843}
+  - component: {fileID: 5169371836113419480}
+  - component: {fileID: 8159341834821911659}
+  m_Layer: 0
+  m_Name: PotionItem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1582631074212584446
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5753383277287633024}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.94, y: 0.3, z: 2.441}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &2541276210167708455
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5753383277287633024}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &1689049321893325843
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5753383277287633024}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: cd25c5347c670b94bbfb90a056b6ef8e, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &5169371836113419480
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5753383277287633024}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 1
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &8159341834821911659
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5753383277287633024}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58792e74ca1573549936ca643652b316, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/LHJ/Prefabs/PotionItem.prefab
+++ b/Assets/LHJ/Prefabs/PotionItem.prefab
@@ -118,3 +118,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 58792e74ca1573549936ca643652b316, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  heal: 1
+  healEffect: {fileID: 904651187185394017, guid: 4dd331fb59a25234dbec6c9e87083bcc, type: 3}

--- a/Assets/LHJ/Prefabs/PotionItem.prefab.meta
+++ b/Assets/LHJ/Prefabs/PotionItem.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: bcebdc1b992ccd74f9db9348dffb31c0
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LHJ/Prefabs/ScoreItem.prefab
+++ b/Assets/LHJ/Prefabs/ScoreItem.prefab
@@ -118,4 +118,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0db988db135353b4a924af88e723727b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  scoreIncrease: 0
+  scoreIncrease: 100
+  scoreEffect: {fileID: 6220918490801148041, guid: a736f18f5f57a4a40aba40a462e9fd8e, type: 3}

--- a/Assets/LHJ/Prefabs/ScoreItem.prefab
+++ b/Assets/LHJ/Prefabs/ScoreItem.prefab
@@ -1,0 +1,120 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &1926466682829534211
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6565743161281872615}
+  - component: {fileID: 3825255691984694917}
+  - component: {fileID: 5573640111971110992}
+  - component: {fileID: 5058977986940791337}
+  - component: {fileID: 8005697506882098260}
+  m_Layer: 0
+  m_Name: ScoreItem
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6565743161281872615
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1926466682829534211}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.69, y: 0.3, z: 2.441}
+  m_LocalScale: {x: 0.5, y: 0.5, z: 0.5}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!33 &3825255691984694917
+MeshFilter:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1926466682829534211}
+  m_Mesh: {fileID: 10202, guid: 0000000000000000e000000000000000, type: 0}
+--- !u!23 &5573640111971110992
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1926466682829534211}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_StaticShadowCaster: 0
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 2100000, guid: ee91e59881146564b8f1b22f0164cc5f, type: 2}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!65 &5058977986940791337
+BoxCollider:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1926466682829534211}
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_IsTrigger: 0
+  m_ProvidesContacts: 0
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Size: {x: 1, y: 1, z: 1}
+  m_Center: {x: 0, y: 0, z: 0}
+--- !u!114 &8005697506882098260
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1926466682829534211}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0db988db135353b4a924af88e723727b, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 

--- a/Assets/LHJ/Prefabs/ScoreItem.prefab
+++ b/Assets/LHJ/Prefabs/ScoreItem.prefab
@@ -100,7 +100,7 @@ BoxCollider:
     serializedVersion: 2
     m_Bits: 0
   m_LayerOverridePriority: 0
-  m_IsTrigger: 0
+  m_IsTrigger: 1
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
@@ -118,3 +118,4 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0db988db135353b4a924af88e723727b, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  scoreIncrease: 0

--- a/Assets/LHJ/Prefabs/ScoreItem.prefab.meta
+++ b/Assets/LHJ/Prefabs/ScoreItem.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 13971cd3cfc2cd644a97b60ae2357ca7
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LHJ/Scripts/AttackItem.cs
+++ b/Assets/LHJ/Scripts/AttackItem.cs
@@ -7,6 +7,7 @@ public class AttackItem : Item
 {
     [SerializeField] private int attackIncrease;
     [SerializeField] private float buffTime;
+    [SerializeField] private GameObject powerupEffect;
 
 
     private void OnTriggerEnter(Collider other)
@@ -24,6 +25,11 @@ public class AttackItem : Item
         if (playerController != null)
         {
             playerController.StartCoroutine(TemporaryAttackBuff(playerController));
+            if (powerupEffect != null)
+            {
+                GameObject effect = Instantiate(powerupEffect, player.transform.position, Quaternion.identity);
+                Destroy(effect, 5f); 
+            }
         }
 
         Destroy(gameObject); 

--- a/Assets/LHJ/Scripts/AttackItem.cs
+++ b/Assets/LHJ/Scripts/AttackItem.cs
@@ -16,6 +16,7 @@ public class AttackItem : Item
             RunItem();
         }
     }
+    // 아이템 효과 실행
     public override void RunItem()
     {
         GameObject player = GameObject.FindGameObjectWithTag("Player");
@@ -27,10 +28,11 @@ public class AttackItem : Item
 
         Destroy(gameObject); 
     }
+    // 일정시간 동안 공격력 증가 및 복구
     private IEnumerator TemporaryAttackBuff(Testplayercontroll player)
     {
-        player.IncreaseAttack(attackIncrease);
-        yield return new WaitForSeconds(buffTime);
-        player.IncreaseAttack(-attackIncrease);
+        player.IncreaseAttack(attackIncrease);      // 공격력 증가
+        yield return new WaitForSeconds(buffTime);  // 버프 지속 시간
+        player.IncreaseAttack(-attackIncrease);     // 원래 공격력을 복구
     }
 }

--- a/Assets/LHJ/Scripts/PotionItem.cs
+++ b/Assets/LHJ/Scripts/PotionItem.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class PotionItem : Item
+{
+    [SerializeField] private int heal;
+    private void OnTriggerEnter(Collider other)
+    {
+        if (other.CompareTag("Player"))
+        {
+            RunItem();
+        }
+    }
+    public override void RunItem()
+    {
+        GameObject player = GameObject.FindGameObjectWithTag("Player");
+        Testplayercontroll playerController = player.GetComponent<Testplayercontroll>();
+        if (playerController != null)
+        {
+            playerController.Heal(heal);
+        }
+        Destroy(gameObject);
+    }
+}

--- a/Assets/LHJ/Scripts/PotionItem.cs
+++ b/Assets/LHJ/Scripts/PotionItem.cs
@@ -18,8 +18,15 @@ public class PotionItem : Item
         Testplayercontroll playerController = player.GetComponent<Testplayercontroll>();
         if (playerController != null)
         {
-            playerController.Heal(heal);
-        }
-        Destroy(gameObject);
+            bool healed = playerController.Heal(heal);
+            if (healed)
+            {
+                Destroy(gameObject);
+            }
+            else
+            {
+
+            }
+        }  
     }
 }

--- a/Assets/LHJ/Scripts/PotionItem.cs
+++ b/Assets/LHJ/Scripts/PotionItem.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class PotionItem : Item
 {
     [SerializeField] private int heal;
+    [SerializeField] private GameObject healEffect;
     private void OnTriggerEnter(Collider other)
     {
         if (other.CompareTag("Player"))
@@ -21,6 +22,11 @@ public class PotionItem : Item
             bool healed = playerController.Heal(heal);
             if (healed)
             {
+                if (healEffect != null)
+                {
+                    GameObject effect = Instantiate(healEffect, player.transform.position, Quaternion.identity);
+                    Destroy(effect, 3f);
+                }
                 Destroy(gameObject);
             }
             else

--- a/Assets/LHJ/Scripts/PotionItem.cs.meta
+++ b/Assets/LHJ/Scripts/PotionItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58792e74ca1573549936ca643652b316
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LHJ/Scripts/ScoreItem.cs
+++ b/Assets/LHJ/Scripts/ScoreItem.cs
@@ -1,0 +1,18 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class ScoreItem : MonoBehaviour
+{
+    // Start is called before the first frame update
+    void Start()
+    {
+        
+    }
+
+    // Update is called once per frame
+    void Update()
+    {
+        
+    }
+}

--- a/Assets/LHJ/Scripts/ScoreItem.cs
+++ b/Assets/LHJ/Scripts/ScoreItem.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 public class ScoreItem : Item
 {
     [SerializeField] private int scoreIncrease;
+    [SerializeField] private GameObject scoreEffect;
     private void OnTriggerEnter(Collider other)
     {
         if (other.CompareTag("Player"))
@@ -19,6 +20,11 @@ public class ScoreItem : Item
         if (playerController != null)
         {
             playerController.IncreaseScore(scoreIncrease);
+            if (scoreEffect != null)
+            {
+                GameObject effect = Instantiate(scoreEffect, player.transform.position, Quaternion.identity);
+                Destroy(effect, 3f); 
+            }
         }
         Destroy(gameObject);
     }

--- a/Assets/LHJ/Scripts/ScoreItem.cs
+++ b/Assets/LHJ/Scripts/ScoreItem.cs
@@ -2,17 +2,24 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
-public class ScoreItem : MonoBehaviour
+public class ScoreItem : Item
 {
-    // Start is called before the first frame update
-    void Start()
+    [SerializeField] private int scoreIncrease;
+    private void OnTriggerEnter(Collider other)
     {
-        
+        if (other.CompareTag("Player"))
+        {
+            RunItem();
+        }
     }
-
-    // Update is called once per frame
-    void Update()
+    public override void RunItem()
     {
-        
+        GameObject player = GameObject.FindGameObjectWithTag("Player");
+        Testplayercontroll playerController = player.GetComponent<Testplayercontroll>();
+        if (playerController != null)
+        {
+            playerController.IncreaseScore(scoreIncrease);
+        }
+        Destroy(gameObject);
     }
 }

--- a/Assets/LHJ/Scripts/ScoreItem.cs.meta
+++ b/Assets/LHJ/Scripts/ScoreItem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0db988db135353b4a924af88e723727b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/LHJ/Scripts/SpeedItem.cs
+++ b/Assets/LHJ/Scripts/SpeedItem.cs
@@ -24,6 +24,8 @@ public class SpeedItem : Item
         }
         Destroy(gameObject);
     }
+
+    // 일정 시간 동안 이동속도 증가 및 복구
     private IEnumerator TemporaryAttackBuff(Testplayercontroll player)
     {
         player.IncreaseSpeed(speedIncrease);

--- a/Assets/LHJ/Scripts/Testplayercontroll.cs
+++ b/Assets/LHJ/Scripts/Testplayercontroll.cs
@@ -9,6 +9,8 @@ public class Testplayercontroll : MonoBehaviour
     [SerializeField] private float playerSpeed;
     [SerializeField] private int attack;
     [SerializeField] private int score;
+    [SerializeField] private int maxHp;
+    [SerializeField] private int currentHp;
 
     private Vector3 inputVec;
     void Update()
@@ -43,5 +45,11 @@ public class Testplayercontroll : MonoBehaviour
     {
         score += amount;
         Debug.Log("점수" + score);
+    }
+
+    public void Heal(int amount)
+    {
+        currentHp += amount;
+        Debug.Log($"현재 체력: {currentHp}/{maxHp}");
     }
 }

--- a/Assets/LHJ/Scripts/Testplayercontroll.cs
+++ b/Assets/LHJ/Scripts/Testplayercontroll.cs
@@ -47,9 +47,17 @@ public class Testplayercontroll : MonoBehaviour
         Debug.Log("점수" + score);
     }
 
-    public void Heal(int amount)
+    public bool Heal(int amount)
     {
+        if(currentHp >= maxHp)
+        {
+            Debug.Log("체력이 가득찼습니다.");
+            return false;
+        }
         currentHp += amount;
+        if (currentHp > maxHp)
+            currentHp = maxHp;
         Debug.Log($"현재 체력: {currentHp}/{maxHp}");
+        return true;
     }
 }

--- a/Assets/LHJ/Scripts/Testplayercontroll.cs
+++ b/Assets/LHJ/Scripts/Testplayercontroll.cs
@@ -8,6 +8,7 @@ public class Testplayercontroll : MonoBehaviour
     [SerializeField] private Rigidbody rigid;
     [SerializeField] private float playerSpeed;
     [SerializeField] private int attack;
+    [SerializeField] private int score;
 
     private Vector3 inputVec;
     void Update()
@@ -37,5 +38,10 @@ public class Testplayercontroll : MonoBehaviour
     {
         playerSpeed += amount;
         Debug.Log("스피드" + playerSpeed);
+    }
+    public void IncreaseScore(int amount)
+    {
+        score += amount;
+        Debug.Log("점수" + score);
     }
 }

--- a/Assets/LHJ/TestScene.unity
+++ b/Assets/LHJ/TestScene.unity
@@ -752,6 +752,10 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 8005697506882098260, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: scoreEffect
+      value: 
+      objectReference: {fileID: 6220918490801148041, guid: a736f18f5f57a4a40aba40a462e9fd8e, type: 3}
+    - target: {fileID: 8005697506882098260, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
       propertyPath: scoreIncrease
       value: 100
       objectReference: {fileID: 0}

--- a/Assets/LHJ/TestScene.unity
+++ b/Assets/LHJ/TestScene.unity
@@ -640,7 +640,8 @@ MonoBehaviour:
   playerSpeed: 3
   attack: 10
   score: 30
-  Hp: 5
+  maxHp: 5
+  currentHp: 4
 --- !u!1001 &209021693501037384
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/LHJ/TestScene.unity
+++ b/Assets/LHJ/TestScene.unity
@@ -641,7 +641,7 @@ MonoBehaviour:
   attack: 10
   score: 30
   maxHp: 5
-  currentHp: 4
+  currentHp: 5
 --- !u!1001 &209021693501037384
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/LHJ/TestScene.unity
+++ b/Assets/LHJ/TestScene.unity
@@ -361,6 +361,63 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speedIncrease: 2
   buffTime: 5
+--- !u!1001 &1674483629
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1926466682829534211, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_Name
+      value: ScoreItem
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.441
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
 --- !u!1 &1777814272
 GameObject:
   m_ObjectHideFlags: 0
@@ -699,71 +756,6 @@ MonoBehaviour:
   score: 30
   maxHp: 5
   currentHp: 2
---- !u!1001 &4919147033477230100
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1926466682829534211, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_Name
-      value: ScoreItem
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: -0.69
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.441
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 8005697506882098260, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: scoreEffect
-      value: 
-      objectReference: {fileID: 6220918490801148041, guid: a736f18f5f57a4a40aba40a462e9fd8e, type: 3}
-    - target: {fileID: 8005697506882098260, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
-      propertyPath: scoreIncrease
-      value: 100
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
 --- !u!1001 &5249362883190243759
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -834,5 +826,5 @@ SceneRoots:
   - {fileID: 2118290006}
   - {fileID: 942265763}
   - {fileID: 5249362883190243759}
-  - {fileID: 4919147033477230100}
   - {fileID: 468931052}
+  - {fileID: 1674483629}

--- a/Assets/LHJ/TestScene.unity
+++ b/Assets/LHJ/TestScene.unity
@@ -640,6 +640,72 @@ MonoBehaviour:
   playerSpeed: 3
   attack: 10
   score: 30
+  Hp: 5
+--- !u!1001 &209021693501037384
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.441
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5753383277287633024, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_Name
+      value: PotionItem
+      objectReference: {fileID: 0}
+    - target: {fileID: 8159341834821911659, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: heal
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 8159341834821911659, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: hpIncrease
+      value: 1
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
 --- !u!1001 &4919147033477230100
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -772,3 +838,4 @@ SceneRoots:
   - {fileID: 942265763}
   - {fileID: 5249362883190243759}
   - {fileID: 4919147033477230100}
+  - {fileID: 209021693501037384}

--- a/Assets/LHJ/TestScene.unity
+++ b/Assets/LHJ/TestScene.unity
@@ -639,6 +639,68 @@ MonoBehaviour:
   rigid: {fileID: 2118290002}
   playerSpeed: 3
   attack: 10
+  score: 30
+--- !u!1001 &4919147033477230100
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1926466682829534211, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_Name
+      value: ScoreItem
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: -0.69
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.441
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 6565743161281872615, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8005697506882098260, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
+      propertyPath: scoreIncrease
+      value: 100
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 13971cd3cfc2cd644a97b60ae2357ca7, type: 3}
 --- !u!1001 &5249362883190243759
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -709,3 +771,4 @@ SceneRoots:
   - {fileID: 2118290006}
   - {fileID: 942265763}
   - {fileID: 5249362883190243759}
+  - {fileID: 4919147033477230100}

--- a/Assets/LHJ/TestScene.unity
+++ b/Assets/LHJ/TestScene.unity
@@ -122,6 +122,63 @@ NavMeshSettings:
     debug:
       m_Flags: 0
   m_NavMeshData: {fileID: 0}
+--- !u!1001 &468931052
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    serializedVersion: 3
+    m_TransformParent: {fileID: 0}
+    m_Modifications:
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0.94
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0.3
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 2.441
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 5753383277287633024, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+      propertyPath: m_Name
+      value: PotionItem
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+    m_RemovedGameObjects: []
+    m_AddedGameObjects: []
+    m_AddedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
 --- !u!1001 &942265763
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -618,7 +675,7 @@ Transform:
   m_GameObject: {fileID: 2118290001}
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0.39, z: 0}
+  m_LocalPosition: {x: -0.75, y: 0.39, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -641,72 +698,7 @@ MonoBehaviour:
   attack: 10
   score: 30
   maxHp: 5
-  currentHp: 5
---- !u!1001 &209021693501037384
-PrefabInstance:
-  m_ObjectHideFlags: 0
-  serializedVersion: 2
-  m_Modification:
-    serializedVersion: 3
-    m_TransformParent: {fileID: 0}
-    m_Modifications:
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalPosition.x
-      value: 0.94
-      objectReference: {fileID: 0}
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalPosition.y
-      value: 0.3
-      objectReference: {fileID: 0}
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalPosition.z
-      value: 2.441
-      objectReference: {fileID: 0}
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalRotation.w
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalRotation.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalRotation.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalRotation.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.x
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 1582631074212584446, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_LocalEulerAnglesHint.z
-      value: 0
-      objectReference: {fileID: 0}
-    - target: {fileID: 5753383277287633024, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: m_Name
-      value: PotionItem
-      objectReference: {fileID: 0}
-    - target: {fileID: 8159341834821911659, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: heal
-      value: 1
-      objectReference: {fileID: 0}
-    - target: {fileID: 8159341834821911659, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
-      propertyPath: hpIncrease
-      value: 1
-      objectReference: {fileID: 0}
-    m_RemovedComponents: []
-    m_RemovedGameObjects: []
-    m_AddedGameObjects: []
-    m_AddedComponents: []
-  m_SourcePrefab: {fileID: 100100000, guid: bcebdc1b992ccd74f9db9348dffb31c0, type: 3}
+  currentHp: 2
 --- !u!1001 &4919147033477230100
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -839,4 +831,4 @@ SceneRoots:
   - {fileID: 942265763}
   - {fileID: 5249362883190243759}
   - {fileID: 4919147033477230100}
-  - {fileID: 209021693501037384}
+  - {fileID: 468931052}


### PR DESCRIPTION
ScoreItem을 통해 ScoreItem을 먹으면 플레이어가 추가로 점수를 얻을 수 있게 구현.
PotionItem을 통해 플레이어의 체력이 닳아있으면 체력 1을 회복 시켜주고 플레이어 체력이 닳지 않은채로 먹으려하면 PotionItem이 사라지지않고 체력이 가득 차있다는 debug.log가 뜬다.
현재 Attack, Score, Potion에 이펙트를 추가하였고 SpeedItem에는 아직 이펙트를 추가하지 못한 상태 입니다. 
이후에 SpeedItem에 이펙트 추가 및 현재 이펙트들이 플레이어 주위에 붙어 있지 않고  먹는 즉시 그 자리에만 이펙트가 형성이 되어서 추후 이 문제를 수정 할 예정.