### PR TITLE
[Fix] 정보UI오류 수정

### DIFF
--- a/Assets/KMS/SCRIPTS/GameManager.cs
+++ b/Assets/KMS/SCRIPTS/GameManager.cs
@@ -61,6 +61,10 @@ public class GameManager : Singleton<GameManager>
     {
         SetInstance();
     }
+    private void OnEnable()
+    {
+        currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
+    }
     private void Start()
     {
         Init();
@@ -79,7 +83,7 @@ public class GameManager : Singleton<GameManager>
     {
         lifePoint = initialLifePoint;
         lastOpenedSceneIndex = -1;
-        currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
+        //currentSceneIndex = SceneManager.GetActiveScene().buildIndex;
     }
     // 지정한 인덱스의 씬으로 이동합니다.
     public void LoadScene(int index)

--- a/Assets/KMS/SCRIPTS/StageManager.cs
+++ b/Assets/KMS/SCRIPTS/StageManager.cs
@@ -61,6 +61,7 @@ public class StageManager : Singleton<StageManager>
     private void Start()
     {
         GameManager.Instance.onSceneLoaded.AddListener(SetStageValues);
+        SetStageValues(GameManager.Instance.CurrentSceneIndex);
     }
 
     private void Update()

--- a/Assets/KMS/SCRIPTS/UIManager.cs
+++ b/Assets/KMS/SCRIPTS/UIManager.cs
@@ -29,6 +29,7 @@ public class UIManager : Singleton<UIManager>
     {
         Init();
         GameManager.Instance.onSceneLoaded.AddListener(ToggleInfoUI);
+        ToggleInfoUI(GameManager.Instance.CurrentSceneIndex);
     }
 
     // 세팅을 초기화합니다.


### PR DESCRIPTION
게임매니저를 현재 씬에 포함시키고 게임을 동작시킬 시, 다음 씬이 로드되기 전까지 정보 UI가 뜨지 않던 오류를 수정했습니다.